### PR TITLE
fix javadoc warnings

### DIFF
--- a/base/src/main/java/iu/ParallelTaskController.java
+++ b/base/src/main/java/iu/ParallelTaskController.java
@@ -48,7 +48,7 @@ import edu.iu.UnsafeRunnable;
  * Controls execution of a single task.
  * 
  * <p>
- * This class implements the composite aggregation of {@link IuTaskConroller} by
+ * This class implements the composite aggregation of {@link IuTaskController} by
  * {@link IuParallelWorkloadController}.
  * </p>
  */

--- a/client/src/main/java/iu/client/EnumerationAdapter.java
+++ b/client/src/main/java/iu/client/EnumerationAdapter.java
@@ -47,7 +47,6 @@ class EnumerationAdapter<E> extends JsonArrayAdapter<Enumeration<E>, E> {
 	 * Constructor
 	 * 
 	 * @param itemAdapter item adapter
-	 * @param factory     creates a new collection
 	 */
 	protected EnumerationAdapter(IuJsonAdapter<E> itemAdapter) {
 		super(itemAdapter);

--- a/client/src/main/java/iu/client/IterableAdapter.java
+++ b/client/src/main/java/iu/client/IterableAdapter.java
@@ -47,7 +47,6 @@ class IterableAdapter<E> extends JsonArrayAdapter<Iterable<E>, E> {
 	 * Constructor
 	 * 
 	 * @param itemAdapter item adapter
-	 * @param factory     creates a new collection
 	 */
 	protected IterableAdapter(IuJsonAdapter<E> itemAdapter) {
 		super(itemAdapter);

--- a/client/src/main/java/iu/client/IteratorAdapter.java
+++ b/client/src/main/java/iu/client/IteratorAdapter.java
@@ -47,7 +47,6 @@ class IteratorAdapter<E> extends JsonArrayAdapter<Iterator<E>, E> {
 	 * Constructor
 	 * 
 	 * @param itemAdapter item adapter
-	 * @param factory     creates a new collection
 	 */
 	protected IteratorAdapter(IuJsonAdapter<E> itemAdapter) {
 		super(itemAdapter);

--- a/client/src/main/java/iu/client/JsonAdapters.java
+++ b/client/src/main/java/iu/client/JsonAdapters.java
@@ -99,7 +99,7 @@ public final class JsonAdapters {
 	 * 
 	 * @param type         Java type
 	 * @param valueAdapter value type adapter
-	 * @return {@link JsonAdapter}
+	 * @return {@link IuJsonAdapter}
 	 */
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public static IuJsonAdapter adapt(Type type, Function<Class<?>, IuJsonAdapter<?>> valueAdapter) {

--- a/client/src/main/java/iu/client/StreamAdapter.java
+++ b/client/src/main/java/iu/client/StreamAdapter.java
@@ -49,7 +49,6 @@ class StreamAdapter<E> extends JsonArrayAdapter<Stream<E>, E> {
 	 * Constructor
 	 * 
 	 * @param itemAdapter item adapter
-	 * @param factory     creates a new collection
 	 */
 	protected StreamAdapter(IuJsonAdapter<E> itemAdapter) {
 		super(itemAdapter);

--- a/client/src/main/java/iu/client/TextJsonAdapter.java
+++ b/client/src/main/java/iu/client/TextJsonAdapter.java
@@ -48,6 +48,13 @@ class TextJsonAdapter implements IuJsonAdapter<CharSequence> {
 	 * Singleton instance.
 	 */
 	static TextJsonAdapter INSTANCE = new TextJsonAdapter();
+	
+	/**
+	 * Default Constructor
+	 */
+	private TextJsonAdapter() {
+		// singleton
+	}
 
 	@Override
 	public String fromJson(JsonValue value) {

--- a/client/src/main/java/iu/client/Vault.java
+++ b/client/src/main/java/iu/client/Vault.java
@@ -76,7 +76,7 @@ public final class Vault implements IuVault {
 	 * Implements {@link IuVault#of(Properties, Function)}.
 	 * 
 	 * @param properties   optional property overrides
-	 * @param valueAdapter
+	 * @param valueAdapter value adapter function
 	 * @return {@link Vault} instance
 	 */
 	public static Vault of(Properties properties, Function<Type, IuJsonAdapter<?>> valueAdapter) {

--- a/crypt/impl/src/main/java/iu/crypt/CompactEncoded.java
+++ b/crypt/impl/src/main/java/iu/crypt/CompactEncoded.java
@@ -42,7 +42,7 @@ import edu.iu.client.IuJson;
 import jakarta.json.JsonObject;
 
 /**
- * Encodes {@link byte[]} values for inclusion in JWS and JWE serialized forms
+ * Encodes {@code byte[]} values for inclusion in JWS and JWE serialized forms
  * as unpadded Base64 URL encoded strings.
  */
 public final class CompactEncoded {

--- a/jdbc/pool/src/main/java/edu/iu/jdbc/pool/IuPooledConnection.java
+++ b/jdbc/pool/src/main/java/edu/iu/jdbc/pool/IuPooledConnection.java
@@ -511,7 +511,7 @@ public class IuPooledConnection implements PooledConnection, ConnectionEventList
 	/**
 	 * Gets the number of times this connection has been used.
 	 * 
-	 * @return {@link long}
+	 * @return {@code long}
 	 */
 	public long getTransactionSegmentCount() {
 		return transactionSegmentCount;

--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
-					<version>0.8.10</version>
+					<version>0.8.14</version>
 					<configuration>
 						<skip>${skipTests}</skip>
 					</configuration>

--- a/type/loader/src/main/java/iu/type/loader/LoadedComponent.java
+++ b/type/loader/src/main/java/iu/type/loader/LoadedComponent.java
@@ -56,7 +56,7 @@ public class LoadedComponent implements IuLoadedComponent {
 	 * @param parentLayer                      parent {@link ModuleLayer}
 	 * 
 	 * @param controllerCallback               receives a reference to an
-	 *                                         {@link IuComponentController} that
+	 *                                         {@link Controller} that
 	 *                                         may be used to set up access rules
 	 *                                         for the component. This reference
 	 *                                         <em>should not</em> be passed beyond
@@ -67,7 +67,7 @@ public class LoadedComponent implements IuLoadedComponent {
 	 * @param providedDependencyArchiveSources {@link InputStream}s for reading all
 	 *                                         <strong>provided dependency
 	 *                                         archives</strong>.
-	 * @throws IOException If an IO error occurs initializing the component
+	 * @throws IllegalStateException custom throwable or Error If an error occurs initializing the component
 	 */
 	public LoadedComponent(ClassLoader parent, ModuleLayer parentLayer, Consumer<Controller> controllerCallback,
 			InputStream componentArchiveSource, InputStream... providedDependencyArchiveSources) {

--- a/type/loader/src/main/java/iu/type/loader/LoadedComponent.java
+++ b/type/loader/src/main/java/iu/type/loader/LoadedComponent.java
@@ -56,18 +56,21 @@ public class LoadedComponent implements IuLoadedComponent {
 	 * @param parentLayer                      parent {@link ModuleLayer}
 	 * 
 	 * @param controllerCallback               receives a reference to an
-	 *                                         {@link Controller} that
-	 *                                         may be used to set up access rules
-	 *                                         for the component. This reference
-	 *                                         <em>should not</em> be passed beyond
-	 *                                         the scope of the callback; see
+	 *                                         {@link Controller} that may be used
+	 *                                         to set up access rules for the
+	 *                                         component. This reference <em>should
+	 *                                         not</em> be passed beyond the scope
+	 *                                         of the callback; see
 	 *                                         {@link ModularClassLoader}
 	 * @param componentArchiveSource           {@link InputStream} for reading the
 	 *                                         <strong>component archive</strong>.
 	 * @param providedDependencyArchiveSources {@link InputStream}s for reading all
 	 *                                         <strong>provided dependency
 	 *                                         archives</strong>.
-	 * @throws IllegalStateException custom throwable or Error If an error occurs initializing the component
+	 * @throws IllegalStateException           if {@code throwable} is a {@link Exception
+	 *                                         checked exception} or {@link Throwable custom
+	 *                                         throwable}
+	 * @throws Error                           if {@code throwable} is an {@link Error}
 	 */
 	public LoadedComponent(ClassLoader parent, ModuleLayer parentLayer, Consumer<Controller> controllerCallback,
 			InputStream componentArchiveSource, InputStream... providedDependencyArchiveSources) {


### PR DESCRIPTION
Attempt to fix javadoc warnings when building latest develop branch. Likely something that could have been fixed in a better way. JaCoCo version update was to fix errors that seem to be related to JaCoCo with lines like the following where there were groups of `Error while instrumenting...Caused by java.io.IOException...Caused by: ...Unsupported class file major version 69`
```
java.lang.instrument.IllegalClassFormatException: Error while instrumenting edu/iu/logging/IuLogContext$MockitoMock$KC6AEvmt$auxiliary$pW6JAnJ9 with JaCoCo 0.8.10.202304240956/8ea9668.
...
java.lang.instrument.IllegalClassFormatException: Error while instrumenting edu/iu/UnsafeSupplier$MockitoMock$eTtYA1vB$auxiliary$s6rXYO3Y with JaCoCo 0.8.10.202304240956/8ea9668.
...
Caused by: java.io.IOException: Error while instrumenting edu/iu/UnsafeSupplier$MockitoMock$eTtYA1vB$auxiliary$s6rXYO3Y with JaCoCo 0.8.10.202304240956/8ea9668.
...
Caused by: java.lang.IllegalArgumentException: Unsupported class file major version 69
```